### PR TITLE
Swallow strange error message on Azure storage account creation with try catch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ steps:
     inlineScript: |
         $accountNameExists = az storage account check-name --name mathdojouibuild$(Build.SourceBranchName) --subscription 5594cd6c-b674-4323-8517-5e859a399468 | ConvertFrom-Json
         If ($accountNameExists.nameAvailable) {
-          az storage account create --name mathdojouibuild$(Build.SourceBranchName) --kind StorageV2 --location uksouth --resource-group math-dojo-hzprod-web-ui
+          az storage account create --name mathdojouibuild$(Build.SourceBranchName) --kind StorageV2 --location uksouth --resource-group math-dojo-hzprod-web-ui --debug
 
           $accountCreated = False
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,9 +48,7 @@ steps:
     inlineScript: |
         $accountNameExists = az storage account check-name --name mathdojouibuild$(Build.SourceBranchName) --subscription 5594cd6c-b674-4323-8517-5e859a399468 | ConvertFrom-Json
         If ($accountNameExists.nameAvailable) {
-
-        $accountCreateCommandOutput  = az storage account create --name mathdojouibuild$(Build.SourceBranchName) --kind StorageV2 --location uksouth --resource-group math-dojo-hzprod-web-ui --sku Standard_RAGRS | ConvertFrom-Json
-        Write-Output $accountCreateCommandOutput
+          az storage account create --name mathdojouibuild$(Build.SourceBranchName) --kind StorageV2 --location uksouth --resource-group math-dojo-hzprod-web-ui
 
           $accountCreated = False
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,13 @@ steps:
     inlineScript: |
         $accountNameExists = az storage account check-name --name mathdojouibuild$(Build.SourceBranchName) --subscription 5594cd6c-b674-4323-8517-5e859a399468 | ConvertFrom-Json
         If ($accountNameExists.nameAvailable) {
-          az storage account create --name mathdojouibuild$(Build.SourceBranchName) --kind StorageV2 --location uksouth --resource-group math-dojo-hzprod-web-ui --debug
+          try { 
+            az storage account create --name mathdojouibuild$(Build.SourceBranchName) --kind StorageV2 --location uksouth --resource-group math-dojo-hzprod-web-ui
+          }
+          catch {
+            Write-Host "An error occurred:"
+            Write-Host $_
+          }
 
           $accountCreated = False
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,14 +55,6 @@ steps:
             Write-Host "An error occurred:"
             Write-Host $_
           }
-
-          $accountCreated = False
-
-          while(! $accountCreated) {
-            Start-Sleep -Seconds 30
-            $accountCreatedJson = (az storage account check-name --name mathdojouibuild$(Build.SourceBranchName) --subscription 5594cd6c-b674-4323-8517-5e859a399468 | ConvertFrom-Json)
-            $accountCreated = $accountCreatedJson.nameAvailable
-          }
         }
         
         az storage blob service-properties update --account-name mathdojouibuild$(Build.SourceBranchName) --static-website --index-document index.html


### PR DESCRIPTION
Pipeline task to create an storage container fails with very little information about the error:
https://dev.azure.com/essiennsikan/Math-Dojo-UI/_build/results?buildId=28&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=c5958238-e176-5f5e-fbd6-97d2d6242272&l=51

This try-catch is to swallow this error and allow the build to continue (given that so far the command still resulted in the correct creation of the storage account.