### PR TITLE
Custom Validation for Question Auth Area

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9925,9 +9925,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash-id": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2811,6 +2811,51 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
+      "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -2884,6 +2929,21 @@
       "version": "3.0.16",
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz",
       "integrity": "sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.4.tgz",
+      "integrity": "sha512-sJmb32asJZY6Z2u09bl0G2wglSxDlROlAejCjsnor+LzBMz17gu8IU7vKC/vWDnv9zEq2wqADHVXFjf4eE8Gdw==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
+      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
       "dev": true
     },
     "@types/source-list-map": {
@@ -8890,6 +8950,12 @@
         "set-immediate-shim": "~1.0.1"
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "karma": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-4.1.0.tgz",
@@ -9876,6 +9942,12 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -10700,6 +10772,36 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-fetch-npm": {
       "version": "2.0.4",
@@ -13869,6 +13971,44 @@
         }
       }
     },
+    "sinon": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
+      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -15292,6 +15432,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-fest": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/jasmine": "~3.3.8",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.12.47",
+    "@types/sinon": "^9.0.4",
     "codelyzer": "^5.2.2",
     "concurrently": "^5.2.0",
     "jasmine-core": "~3.4.0",
@@ -64,6 +65,7 @@
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.5.4",
     "protractor": "~5.4.0",
+    "sinon": "^9.0.2",
     "ts-node": "~7.0.0",
     "tslint": "~5.15.0",
     "typescript": "3.7.5"

--- a/src/app/components/auth/signup/signup.component.html
+++ b/src/app/components/auth/signup/signup.component.html
@@ -1,43 +1,83 @@
 <div class="login-wrapper">
-    <form class="login mtdj__signupform" [formGroup]="newUserSignupForm" (submit)="onSubmit()">
-        <section class="title">
-            <h3 class="welcome">Welcome to</h3>
-            Math Dojo
-            <h5 class="hint">Create an account - It's quick and easy</h5>
-        </section>
-        <div class="login-group">
-            <clr-input-container>
-                <label class="clr-sr-only">First & Last name</label>
-                <input type="text" name="name" clrInput placeholder="First & Last name" formControlName="name"/>
-            </clr-input-container>
-            <clr-input-container>
-                <label class="clr-sr-only">Email</label>
-                <input type="text" name="email" clrInput placeholder="Email" formControlName="email"/>
-            </clr-input-container>
-            <clr-password-container>
-                <label class="clr-sr-only">Password</label>
-                <input type="password" name="password" clrPassword placeholder="Password" formControlName="password"/>
-            </clr-password-container>
-            <div class="error active" [ngClass]="{'mtdj__remove_error': newUserSignupForm.valid}">
-                Invalid user name or password
-            </div>
-            <button type="submit" [disabled]="!newUserSignupForm.valid" class="btn btn-primary">Sign Up</button>
-            <div class="mtdj__social-login">
-                <div class="mtdj__social-login-label">
-                    <span class="label-text">or connect with</span>
-                </div>
-                <div class="btn-group btn-link mtdj__social-login-icon">
-                    <button class="btn mtdj__social-login-icon-btn">
-                        <img class="mtdj__social-login-icon-btn-logo" src="/assets/facebook.svg">
-                    </button>
-                    <button class="btn mtdj__social-login-icon-btn">
-                        <img class="mtdj__social-login-icon-btn-logo" src="/assets/google.svg">
-                    </button>
-                    <button class="btn mtdj__social-login-icon-btn">
-                        <img class="mtdj__social-login-icon-btn-logo" src="/assets/github.svg">
-                    </button>
-                </div>
-            </div>
+  <form
+    class="login mtdj__signupform"
+    [formGroup]="newUserSignupForm"
+    (ngSubmit)="onSubmit()"
+  >
+    <section class="title">
+      <h3 class="welcome">Welcome to</h3>
+      Math Dojo
+      <h5 class="hint">Create an account - It's quick and easy</h5>
+    </section>
+    <div class="login-group">
+      <clr-input-container>
+        <label class="clr-sr-only">First & Last name</label>
+        <input
+          type="text"
+          name="name"
+          clrInput
+          placeholder="First & Last name"
+          formControlName="name"
+        />
+      </clr-input-container>
+      <clr-input-container>
+        <label class="clr-sr-only">Email</label>
+        <input
+          type="text"
+          name="email"
+          clrInput
+          placeholder="Email"
+          formControlName="email"
+        />
+      </clr-input-container>
+      <clr-password-container>
+        <label class="clr-sr-only">Password</label>
+        <input
+          type="password"
+          name="password"
+          clrPassword
+          placeholder="Password"
+          formControlName="password"
+        />
+      </clr-password-container>
+      <div
+        class="error active"
+        [ngClass]="{ mtdj__remove_error: newUserSignupForm.valid }"
+      >
+        Invalid user name or password
+      </div>
+      <button
+        type="submit"
+        [disabled]="!newUserSignupForm.valid"
+        class="btn btn-primary"
+      >
+        Sign Up
+      </button>
+      <div class="mtdj__social-login">
+        <div class="mtdj__social-login-label">
+          <span class="label-text">or connect with</span>
         </div>
-    </form>
+        <div class="btn-group btn-link mtdj__social-login-icon">
+          <button class="btn mtdj__social-login-icon-btn">
+            <img
+              class="mtdj__social-login-icon-btn-logo"
+              src="/assets/facebook.svg"
+            />
+          </button>
+          <button class="btn mtdj__social-login-icon-btn">
+            <img
+              class="mtdj__social-login-icon-btn-logo"
+              src="/assets/google.svg"
+            />
+          </button>
+          <button class="btn mtdj__social-login-icon-btn">
+            <img
+              class="mtdj__social-login-icon-btn-logo"
+              src="/assets/github.svg"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </form>
 </div>

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
@@ -28,9 +28,9 @@
             <clr-select-container id="mtdj__question-auth-input-difficulty">
               <label>Difficulty</label>
               <select clrSelect formControlName="difficulty">
-                <option value="Easy">Easy</option>
-                <option value="Medium">Medium</option>
-                <option value="Hard">Hard</option>
+                <option *ngFor="let each of difficulty" [value]="each">{{
+                  each
+                }}</option>
               </select>
             </clr-select-container>
 
@@ -132,7 +132,11 @@
               >
             </clr-input-container>
 
-            <button type="submit" class="btn btn-primary">
+            <button
+              type="submit"
+              class="btn btn-primary"
+              [disabled]="!newQuestionForm.valid"
+            >
               Submit Question
             </button>
             <clr-alert

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
@@ -130,7 +130,7 @@
               >
             </clr-input-container>
 
-            <button type="submit" class="btn btn-dark" (click)="onSubmit()">
+            <button type="submit" class="btn btn-primary" (click)="onSubmit()">
               Submit Question
             </button>
             <clr-alert

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
@@ -7,11 +7,11 @@
           class="clr-col-lg-6 clr-col-sm-12 clr-col-md-12 mtdj__question-auth-input-container"
         >
           <form clrForm [formGroup]="newQuestionForm" (ngSubmit)="onSubmit()">
-            <clr-input-container>
+            <clr-input-container id="mtdj__question-auth-input-title">
               <label>Question Title</label>
               <input clrInput formControlName="title" required />
             </clr-input-container>
-            <clr-datalist-container>
+            <clr-datalist-container id="mtdj__question-auth-input-topic">
               <label>Topic Title</label>
               <input
                 formControlName="parentTopicTitle"
@@ -25,7 +25,7 @@
               </datalist>
             </clr-datalist-container>
 
-            <clr-select-container>
+            <clr-select-container id="mtdj__question-auth-input-difficulty">
               <label>Difficulty</label>
               <select clrSelect formControlName="difficulty">
                 <option value="Easy">Easy</option>
@@ -34,7 +34,7 @@
               </select>
             </clr-select-container>
 
-            <clr-textarea-container>
+            <clr-textarea-container id="mtdj__question-auth-input-body">
               <label>Body</label>
               <textarea clrTextarea formControlName="body" required></textarea>
               <clr-control-helper
@@ -42,7 +42,9 @@
               >
             </clr-textarea-container>
 
-            <clr-textarea-container>
+            <clr-textarea-container
+              id="mtdj__question-auth-input-sample_answer"
+            >
               <label>Sample Answer</label>
               <textarea clrTextarea formControlName="sampleAnswer"></textarea>
               <clr-control-helper
@@ -51,7 +53,7 @@
               >
             </clr-textarea-container>
 
-            <clr-textarea-container>
+            <clr-textarea-container id="mtdj__question-auth-input-answer">
               <label>Answer</label>
               <textarea
                 clrTextarea
@@ -60,7 +62,7 @@
               ></textarea>
             </clr-textarea-container>
 
-            <clr-input-container>
+            <clr-input-container id="mtdj__question-auth-input-hint1">
               <label>Hint 1</label>
               <input
                 class=".mtdj__question-auth-input--long"
@@ -68,7 +70,7 @@
                 formControlName="hint1"
               />
             </clr-input-container>
-            <clr-input-container>
+            <clr-input-container id="mtdj__question-auth-input-hint2">
               <label>Hint 2</label>
               <input
                 class=".mtdj__question-auth-input--long"
@@ -76,7 +78,7 @@
                 formControlName="hint2"
               />
             </clr-input-container>
-            <clr-input-container>
+            <clr-input-container id="mtdj__question-auth-input-hint3">
               <label>Hint 3</label>
               <input
                 class=".mtdj__question-auth-input--long"
@@ -85,7 +87,7 @@
               />
             </clr-input-container>
 
-            <clr-input-container>
+            <clr-input-container id="mtdj__question-auth-input-option1">
               <label>Option 1</label>
               <input
                 class=".mtdj__question-auth-input--long"
@@ -96,7 +98,7 @@
                 >Equations should be written in LaTex</clr-control-helper
               >
             </clr-input-container>
-            <clr-input-container>
+            <clr-input-container id="mtdj__question-auth-input-option2">
               <label>Option 2</label>
               <input
                 class=".mtdj__question-auth-input--long"
@@ -107,7 +109,7 @@
                 >Equations should be written in LaTex</clr-control-helper
               >
             </clr-input-container>
-            <clr-input-container>
+            <clr-input-container id="mtdj__question-auth-input-option3">
               <label>Option 3</label>
               <input
                 class=".mtdj__question-auth-input--long"
@@ -118,7 +120,7 @@
                 >Equations should be written in LaTex</clr-control-helper
               >
             </clr-input-container>
-            <clr-input-container>
+            <clr-input-container id="mtdj__question-auth-input-option4">
               <label>Option 4</label>
               <input
                 class=".mtdj__question-auth-input--long"

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
@@ -6,7 +6,7 @@
         <div
           class="clr-col-lg-6 clr-col-sm-12 clr-col-md-12 mtdj__question-auth-input-container"
         >
-          <form clrForm [formGroup]="newQuestionForm">
+          <form clrForm [formGroup]="newQuestionForm" (ngSubmit)="onSubmit()">
             <clr-input-container>
               <label>Question Title</label>
               <input clrInput formControlName="title" required />
@@ -130,7 +130,7 @@
               >
             </clr-input-container>
 
-            <button type="submit" class="btn btn-primary" (click)="onSubmit()">
+            <button type="submit" class="btn btn-primary">
               Submit Question
             </button>
             <clr-alert

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
@@ -160,7 +160,131 @@
               <clr-tab>
                 <button clrTabLink>Preview</button>
                 <clr-tab-content *clrIfActive>
-                  ...
+                  <clr-input-container id="mtdj__question-auth-input-title">
+                    <label>Question Title</label>
+                    <input clrInput formControlName="title" required disabled />
+                  </clr-input-container>
+                  <clr-datalist-container id="mtdj__question-auth-input-topic">
+                    <label>Topic Title</label>
+                    <input
+                      formControlName="parentTopicTitle"
+                      required
+                      clrDatalistInput
+                      disabled
+                    />
+                    <datalist *ngIf="topics$ | async as topics">
+                      <option *ngFor="let topic of topics" [value]="topic.title"
+                        >{{ topic.formattedTitle }}
+                      </option>
+                    </datalist>
+                  </clr-datalist-container>
+
+                  <clr-select-container
+                    id="mtdj__question-auth-input-difficulty"
+                  >
+                    <label>Difficulty</label>
+                    <select clrSelect formControlName="difficulty" disabled>
+                      <option *ngFor="let each of difficulty" [value]="each">{{
+                        each
+                      }}</option>
+                    </select>
+                  </clr-select-container>
+
+                  <clr-textarea-container id="mtdj__question-auth-input-body">
+                    <label>Body</label>
+                    <textarea
+                      clrTextarea
+                      formControlName="body"
+                      required
+                      disabled
+                    ></textarea>
+                  </clr-textarea-container>
+
+                  <clr-textarea-container
+                    id="mtdj__question-auth-input-sample_answer"
+                  >
+                    <label>Sample Answer</label>
+                    <textarea
+                      clrTextarea
+                      formControlName="sampleAnswer"
+                      disabled
+                    ></textarea>
+                  </clr-textarea-container>
+
+                  <clr-textarea-container id="mtdj__question-auth-input-answer">
+                    <label>Answer</label>
+                    <textarea
+                      clrTextarea
+                      formControlName="answer"
+                      required
+                      disabled
+                    ></textarea>
+                  </clr-textarea-container>
+
+                  <clr-input-container id="mtdj__question-auth-input-hint1">
+                    <label>Hint 1</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="hint1"
+                      disabled
+                    />
+                  </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-hint2">
+                    <label>Hint 2</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="hint2"
+                      disabled
+                    />
+                  </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-hint3">
+                    <label>Hint 3</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="hint3"
+                      disabled
+                    />
+                  </clr-input-container>
+
+                  <clr-input-container id="mtdj__question-auth-input-option1">
+                    <label>Option 1</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="option1"
+                      disabled
+                    />
+                  </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-option2">
+                    <label>Option 2</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="option2"
+                      disabled
+                    />
+                  </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-option3">
+                    <label>Option 3</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="option3"
+                      disabled
+                    />
+                  </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-option4">
+                    <label>Option 4</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="option4"
+                      disabled
+                    />
+                  </clr-input-container>
                 </clr-tab-content>
               </clr-tab>
             </clr-tabs>

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
@@ -10,6 +10,9 @@
             <clr-input-container id="mtdj__question-auth-input-title">
               <label>Question Title</label>
               <input clrInput formControlName="title" required />
+              <clr-control-error *clrIfError="'required'"
+                >This is a required field</clr-control-error
+              >
             </clr-input-container>
             <clr-datalist-container id="mtdj__question-auth-input-topic">
               <label>Topic Title</label>
@@ -139,28 +142,6 @@
             >
               Submit Question
             </button>
-            <clr-alert
-              *ngIf="!validateOptions"
-              clrAlertType="danger"
-              [clrAlertClosable]="false"
-            >
-              Please make sure there is more than one option and they are in
-              order.
-            </clr-alert>
-            <clr-alert
-              *ngIf="questionExists"
-              clrAlertType="danger"
-              [clrAlertClosable]="false"
-            >
-              A Question of that title already exists.
-            </clr-alert>
-            <clr-alert
-              *ngIf="submitted"
-              clrAlertType="success"
-              [clrAlertClosable]="false"
-            >
-              Question submission successful.
-            </clr-alert>
           </form>
         </div>
         <div

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
@@ -7,141 +7,163 @@
           class="clr-col-lg-6 clr-col-sm-12 clr-col-md-12 mtdj__question-auth-input-container"
         >
           <form clrForm [formGroup]="newQuestionForm" (ngSubmit)="onSubmit()">
-            <clr-input-container id="mtdj__question-auth-input-title">
-              <label>Question Title</label>
-              <input clrInput formControlName="title" required />
-              <clr-control-error *clrIfError="'required'"
-                >This is a required field</clr-control-error
-              >
-              <clr-control-error *clrIfError="'maxlength'"
-                >This has exceeded the max length of
-                characters</clr-control-error
-              >
-              <clr-control-error *clrIfError="'titleAlreadyExists'">{{
-                newQuestionForm.controls.title.errors.titleAlreadyExists
-                  .errorMessage
-              }}</clr-control-error>
-            </clr-input-container>
-            <clr-datalist-container id="mtdj__question-auth-input-topic">
-              <label>Topic Title</label>
-              <input
-                formControlName="parentTopicTitle"
-                required
-                clrDatalistInput
-              />
-              <datalist *ngIf="topics$ | async as topics">
-                <option *ngFor="let topic of topics" [value]="topic.title"
-                  >{{ topic.formattedTitle }}
-                </option>
-              </datalist>
-            </clr-datalist-container>
+            <clr-tabs>
+              <clr-tab>
+                <button clrTabLink id="link1">Write</button>
+                <clr-tab-content id="content1" *clrIfActive="true">
+                  <clr-input-container id="mtdj__question-auth-input-title">
+                    <label>Question Title</label>
+                    <input clrInput formControlName="title" required />
+                    <clr-control-error *clrIfError="'required'"
+                      >This is a required field</clr-control-error
+                    >
+                    <clr-control-error *clrIfError="'maxlength'"
+                      >This has exceeded the max length of
+                      characters</clr-control-error
+                    >
+                    <clr-control-error *clrIfError="'titleAlreadyExists'">{{
+                      newQuestionForm.controls.title.errors.titleAlreadyExists
+                        .errorMessage
+                    }}</clr-control-error>
+                  </clr-input-container>
+                  <clr-datalist-container id="mtdj__question-auth-input-topic">
+                    <label>Topic Title</label>
+                    <input
+                      formControlName="parentTopicTitle"
+                      required
+                      clrDatalistInput
+                    />
+                    <datalist *ngIf="topics$ | async as topics">
+                      <option *ngFor="let topic of topics" [value]="topic.title"
+                        >{{ topic.formattedTitle }}
+                      </option>
+                    </datalist>
+                  </clr-datalist-container>
 
-            <clr-select-container id="mtdj__question-auth-input-difficulty">
-              <label>Difficulty</label>
-              <select clrSelect formControlName="difficulty">
-                <option *ngFor="let each of difficulty" [value]="each">{{
-                  each
-                }}</option>
-              </select>
-            </clr-select-container>
+                  <clr-select-container
+                    id="mtdj__question-auth-input-difficulty"
+                  >
+                    <label>Difficulty</label>
+                    <select clrSelect formControlName="difficulty">
+                      <option *ngFor="let each of difficulty" [value]="each">{{
+                        each
+                      }}</option>
+                    </select>
+                  </clr-select-container>
 
-            <clr-textarea-container id="mtdj__question-auth-input-body">
-              <label>Body</label>
-              <textarea clrTextarea formControlName="body" required></textarea>
-              <clr-control-helper
-                >Equations should be written in LaTex</clr-control-helper
-              >
-            </clr-textarea-container>
+                  <clr-textarea-container id="mtdj__question-auth-input-body">
+                    <label>Body</label>
+                    <textarea
+                      clrTextarea
+                      formControlName="body"
+                      required
+                    ></textarea>
+                    <clr-control-helper
+                      >Equations should be written in LaTex</clr-control-helper
+                    >
+                  </clr-textarea-container>
 
-            <clr-textarea-container
-              id="mtdj__question-auth-input-sample_answer"
-            >
-              <label>Sample Answer</label>
-              <textarea clrTextarea formControlName="sampleAnswer"></textarea>
-              <clr-control-helper
-                >An example of how to answer the question in a
-                textbox</clr-control-helper
-              >
-            </clr-textarea-container>
+                  <clr-textarea-container
+                    id="mtdj__question-auth-input-sample_answer"
+                  >
+                    <label>Sample Answer</label>
+                    <textarea
+                      clrTextarea
+                      formControlName="sampleAnswer"
+                    ></textarea>
+                    <clr-control-helper
+                      >An example of how to answer the question in a
+                      textbox</clr-control-helper
+                    >
+                  </clr-textarea-container>
 
-            <clr-textarea-container id="mtdj__question-auth-input-answer">
-              <label>Answer</label>
-              <textarea
-                clrTextarea
-                formControlName="answer"
-                required
-              ></textarea>
-            </clr-textarea-container>
+                  <clr-textarea-container id="mtdj__question-auth-input-answer">
+                    <label>Answer</label>
+                    <textarea
+                      clrTextarea
+                      formControlName="answer"
+                      required
+                    ></textarea>
+                  </clr-textarea-container>
 
-            <clr-input-container id="mtdj__question-auth-input-hint1">
-              <label>Hint 1</label>
-              <input
-                class=".mtdj__question-auth-input--long"
-                clrInput
-                formControlName="hint1"
-              />
-            </clr-input-container>
-            <clr-input-container id="mtdj__question-auth-input-hint2">
-              <label>Hint 2</label>
-              <input
-                class=".mtdj__question-auth-input--long"
-                clrInput
-                formControlName="hint2"
-              />
-            </clr-input-container>
-            <clr-input-container id="mtdj__question-auth-input-hint3">
-              <label>Hint 3</label>
-              <input
-                class=".mtdj__question-auth-input--long"
-                clrInput
-                formControlName="hint3"
-              />
-            </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-hint1">
+                    <label>Hint 1</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="hint1"
+                    />
+                  </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-hint2">
+                    <label>Hint 2</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="hint2"
+                    />
+                  </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-hint3">
+                    <label>Hint 3</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="hint3"
+                    />
+                  </clr-input-container>
 
-            <clr-input-container id="mtdj__question-auth-input-option1">
-              <label>Option 1</label>
-              <input
-                class=".mtdj__question-auth-input--long"
-                clrInput
-                formControlName="option1"
-              />
-              <clr-control-helper
-                >Equations should be written in LaTex</clr-control-helper
-              >
-            </clr-input-container>
-            <clr-input-container id="mtdj__question-auth-input-option2">
-              <label>Option 2</label>
-              <input
-                class=".mtdj__question-auth-input--long"
-                clrInput
-                formControlName="option2"
-              />
-              <clr-control-helper
-                >Equations should be written in LaTex</clr-control-helper
-              >
-            </clr-input-container>
-            <clr-input-container id="mtdj__question-auth-input-option3">
-              <label>Option 3</label>
-              <input
-                class=".mtdj__question-auth-input--long"
-                clrInput
-                formControlName="option3"
-              />
-              <clr-control-helper
-                >Equations should be written in LaTex</clr-control-helper
-              >
-            </clr-input-container>
-            <clr-input-container id="mtdj__question-auth-input-option4">
-              <label>Option 4</label>
-              <input
-                class=".mtdj__question-auth-input--long"
-                clrInput
-                formControlName="option4"
-              />
-              <clr-control-helper
-                >Equations should be written in LaTex</clr-control-helper
-              >
-            </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-option1">
+                    <label>Option 1</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="option1"
+                    />
+                    <clr-control-helper
+                      >Equations should be written in LaTex</clr-control-helper
+                    >
+                  </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-option2">
+                    <label>Option 2</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="option2"
+                    />
+                    <clr-control-helper
+                      >Equations should be written in LaTex</clr-control-helper
+                    >
+                  </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-option3">
+                    <label>Option 3</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="option3"
+                    />
+                    <clr-control-helper
+                      >Equations should be written in LaTex</clr-control-helper
+                    >
+                  </clr-input-container>
+                  <clr-input-container id="mtdj__question-auth-input-option4">
+                    <label>Option 4</label>
+                    <input
+                      class=".mtdj__question-auth-input--long"
+                      clrInput
+                      formControlName="option4"
+                    />
+                    <clr-control-helper
+                      >Equations should be written in LaTex</clr-control-helper
+                    >
+                  </clr-input-container>
+                </clr-tab-content>
+              </clr-tab>
+              <clr-tab>
+                <button clrTabLink>Preview</button>
+                <clr-tab-content *clrIfActive>
+                  ...
+                </clr-tab-content>
+              </clr-tab>
+            </clr-tabs>
 
             <button
               type="submit"

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.html
@@ -13,6 +13,14 @@
               <clr-control-error *clrIfError="'required'"
                 >This is a required field</clr-control-error
               >
+              <clr-control-error *clrIfError="'maxlength'"
+                >This has exceeded the max length of
+                characters</clr-control-error
+              >
+              <clr-control-error *clrIfError="'titleAlreadyExists'">{{
+                newQuestionForm.controls.title.errors.titleAlreadyExists
+                  .errorMessage
+              }}</clr-control-error>
             </clr-input-container>
             <clr-datalist-container id="mtdj__question-auth-input-topic">
               <label>Topic Title</label>

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -9,6 +9,8 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { KatexModule } from 'ng-katex';
 import { QuestionService } from 'src/app/services/question.service';
 import { QuestionServiceStub } from 'src/testing/question.service.stub';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
 
 
 describe('QuestionAuthoringPageComponent', () => {
@@ -44,6 +46,17 @@ describe('QuestionAuthoringPageComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call its onSubmit method when its form\'s submit event is triggered', () => {
+    spyOn(component, 'onSubmit');
+
+    const signupElement: DebugElement = fixture.debugElement;
+    const signupFormElement = signupElement.query(By.css('.mtdj__question-auth-input-container form'));
+
+    signupFormElement.triggerEventHandler('submit', null);
+
+    expect(component.onSubmit).toHaveBeenCalledTimes(1);
   });
 
   afterEach(() => {

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -123,13 +123,36 @@ describe('QuestionAuthoringPageComponent', () => {
     });
   });
 
+  describe('Input Validation', () => {
+    it('should allow the length of the question title to be up to 64 chars', () => {
+      const controlName = 'title';
+      const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));
+      const inputQuestionTitle = 'a question title that is very exactly sixty-four characters long';
 
-  //TODO: Write sepearate test case for select option: https://stackoverflow.com/questions/5678210/select-dropdown-menu-option-with-javascript
+      inputFormElement.nativeElement.value = inputQuestionTitle;
+      inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
 
-  let a = 0;
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].valid).toBe(true);
+    });
+
+    it('should allow the length of the question title to be up to 64 chars', () => {
+      const controlName = 'title';
+      const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));
+      const inputQuestionTitle = 'a question title that is very exactly sixty-four characters long';
+      const longerQuestionTitle = `${inputQuestionTitle} more stuff`;
+      inputFormElement.nativeElement.value = longerQuestionTitle;
+      inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
+
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(longerQuestionTitle);
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].invalid).toBe(true);
+    });
+  });
+
+
+  // TODO: Write sepearate test case for select option: https://stackoverflow.com/questions/5678210/select-dropdown-menu-option-with-javascript
+
   afterEach(() => {
-    a++;
-    console.log(`I run for the ${a}st/th time`);
     TestBed.resetTestingModule();
   });
 

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -208,7 +208,7 @@ describe('QuestionAuthoringPageComponent', () => {
   });
 
 
-  // TODO: Write sepearate test case for select option: https://stackoverflow.com/questions/5678210/select-dropdown-menu-option-with-javascript
+  // TODO: Write test case for select option: https://stackoverflow.com/questions/5678210/select-dropdown-menu-option-with-javascript
 
   afterEach(() => {
     TestBed.resetTestingModule();

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -29,7 +29,6 @@ describe('QuestionAuthoringPageComponent', () => {
       declarations: [QuestionAuthoringPageComponent, MtdgFooterComponent, MtdjHeaderComponent],
       imports: [
         ClarityModule,
-        RouterTestingModule,
         ReactiveFormsModule,
         KatexModule
       ],
@@ -176,6 +175,8 @@ describe('QuestionAuthoringPageComponent', () => {
       const inputQuestionTitle = '';
       inputFormElement.nativeElement.value = inputQuestionTitle;
       inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
+      inputFormElement.nativeElement.dispatchEvent(new FocusEvent('blur'));
+      fixture.detectChanges();
 
       // Then
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -139,6 +139,8 @@ describe('QuestionAuthoringPageComponent', () => {
 
       inputFormElement.nativeElement.value = inputQuestionTitle;
       inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
+      inputFormElement.nativeElement.dispatchEvent(new FocusEvent('blur'));
+      fixture.detectChanges();
 
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].valid).toBe(true);
@@ -149,9 +151,10 @@ describe('QuestionAuthoringPageComponent', () => {
       const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));
       const inputQuestionTitle = 'a question title that is very exactly sixty-four characters long';
       const longerQuestionTitle = `${inputQuestionTitle} more stuff`;
+
       inputFormElement.nativeElement.value = longerQuestionTitle;
       inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
-
+      inputFormElement.nativeElement.dispatchEvent(new FocusEvent('blur'));
       fixture.detectChanges();
 
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(longerQuestionTitle);
@@ -191,6 +194,8 @@ describe('QuestionAuthoringPageComponent', () => {
       // When
       inputFormElement.nativeElement.value = inputQuestionTitle;
       inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
+      inputFormElement.nativeElement.dispatchEvent(new FocusEvent('blur'));
+      fixture.detectChanges();
 
       // Then
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -9,7 +9,6 @@ import { createStubInstance, SinonStubbedInstance } from 'sinon';
 import { of } from 'rxjs';
 
 import { QuestionService } from 'src/app/services/question.service';
-import { QuestionServiceStub } from 'src/testing/question.service.stub';
 import { QuestionAuthoringPageComponent } from './question-authoring-page.component';
 import { MtdgFooterComponent } from '../../mtdg-footer/mtdg-footer.component';
 import { MtdjHeaderComponent } from '../../mtdj-header/mtdj-header.component';

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -59,67 +59,70 @@ describe('QuestionAuthoringPageComponent', () => {
     expect(component.onSubmit).toHaveBeenCalledTimes(1);
   });
 
-  const parameters = [
-    {
-      description: 'title input control when text is entered', controlName: 'title',
-      cssSelector: '#mtdj__question-auth-input-title input', inputValue: 'something-really-hard'
-    },
-    {
-      description: 'topic input control when text is entered', controlName: 'parentTopicTitle',
-      cssSelector: '#mtdj__question-auth-input-topic input', inputValue: 'something-really-hard'
-    },
-    {
-      description: 'body input control when text is entered', controlName: 'body',
-      cssSelector: '#mtdj__question-auth-input-body textarea', inputValue: 'some quqestion'
-    },
-    {
-      description: 'sampleAnswer input control when text is entered', controlName: 'sampleAnswer',
-      cssSelector: '#mtdj__question-auth-input-sample_answer textarea', inputValue: 'some sample answer'
-    },
-    {
-      description: 'answer input control when text is entered', controlName: 'answer',
-      cssSelector: '#mtdj__question-auth-input-answer textarea', inputValue: 'some correct answer'
-    },
-    {
-      description: 'hint1 input control when text is entered', controlName: 'hint1',
-      cssSelector: '#mtdj__question-auth-input-hint1 input', inputValue: 'some hint'
-    },
-    {
-      description: 'hint2 input control when text is entered', controlName: 'hint2',
-      cssSelector: '#mtdj__question-auth-input-hint2 input', inputValue: 'some hint'
-    },
-    {
-      description: 'hint3 input control when text is entered', controlName: 'hint3',
-      cssSelector: '#mtdj__question-auth-input-hint3 input', inputValue: 'some hint'
-    },
-    {
-      description: 'option1 input control when text is entered', controlName: 'option1',
-      cssSelector: '#mtdj__question-auth-input-option1 input', inputValue: 'some option'
-    },
-    {
-      description: 'option2 input control when text is entered', controlName: 'option2',
-      cssSelector: '#mtdj__question-auth-input-option2 input', inputValue: 'some option'
-    },
-    {
-      description: 'option3 input control when text is entered', controlName: 'option3',
-      cssSelector: '#mtdj__question-auth-input-option3 input', inputValue: 'some option'
-    },
-    {
-      description: 'option4 input control when text is entered', controlName: 'option4',
-      cssSelector: '#mtdj__question-auth-input-option4 input', inputValue: 'some option'
-    }
-  ];
-  parameters.forEach(({ description, cssSelector, inputValue, controlName }) => {
-    it(`should update the value of the ${description}`, () => {
-      const inputFormElement = fixture.debugElement.query(By.css(cssSelector));
-      const inputQuestionTitle = inputValue;
+  describe('Input controls', () => {
+    const parameters = [
+      {
+        description: 'title input control when text is entered', controlName: 'title',
+        cssSelector: '#mtdj__question-auth-input-title input', inputValue: 'something-really-hard'
+      },
+      {
+        description: 'topic input control when text is entered', controlName: 'parentTopicTitle',
+        cssSelector: '#mtdj__question-auth-input-topic input', inputValue: 'something-really-hard'
+      },
+      {
+        description: 'body input control when text is entered', controlName: 'body',
+        cssSelector: '#mtdj__question-auth-input-body textarea', inputValue: 'some quqestion'
+      },
+      {
+        description: 'sampleAnswer input control when text is entered', controlName: 'sampleAnswer',
+        cssSelector: '#mtdj__question-auth-input-sample_answer textarea', inputValue: 'some sample answer'
+      },
+      {
+        description: 'answer input control when text is entered', controlName: 'answer',
+        cssSelector: '#mtdj__question-auth-input-answer textarea', inputValue: 'some correct answer'
+      },
+      {
+        description: 'hint1 input control when text is entered', controlName: 'hint1',
+        cssSelector: '#mtdj__question-auth-input-hint1 input', inputValue: 'some hint'
+      },
+      {
+        description: 'hint2 input control when text is entered', controlName: 'hint2',
+        cssSelector: '#mtdj__question-auth-input-hint2 input', inputValue: 'some hint'
+      },
+      {
+        description: 'hint3 input control when text is entered', controlName: 'hint3',
+        cssSelector: '#mtdj__question-auth-input-hint3 input', inputValue: 'some hint'
+      },
+      {
+        description: 'option1 input control when text is entered', controlName: 'option1',
+        cssSelector: '#mtdj__question-auth-input-option1 input', inputValue: 'some option'
+      },
+      {
+        description: 'option2 input control when text is entered', controlName: 'option2',
+        cssSelector: '#mtdj__question-auth-input-option2 input', inputValue: 'some option'
+      },
+      {
+        description: 'option3 input control when text is entered', controlName: 'option3',
+        cssSelector: '#mtdj__question-auth-input-option3 input', inputValue: 'some option'
+      },
+      {
+        description: 'option4 input control when text is entered', controlName: 'option4',
+        cssSelector: '#mtdj__question-auth-input-option4 input', inputValue: 'some option'
+      }
+    ];
+    parameters.forEach(({ description, cssSelector, inputValue, controlName }) => {
+      it(`should update the value of the ${description}`, () => {
+        const inputFormElement = fixture.debugElement.query(By.css(cssSelector));
+        const inputQuestionTitle = inputValue;
 
-      inputFormElement.nativeElement.value = inputQuestionTitle;
-      inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
+        inputFormElement.nativeElement.value = inputQuestionTitle;
+        inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
 
-      expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);
+        expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);
+      });
     });
   });
+
 
   //TODO: Write sepearate test case for select option: https://stackoverflow.com/questions/5678210/select-dropdown-menu-option-with-javascript
 

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -59,14 +59,34 @@ describe('QuestionAuthoringPageComponent', () => {
     expect(component.onSubmit).toHaveBeenCalledTimes(1);
   });
 
-  it('should update the value of the question title control when text is entered', () => {
-    const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));
-    const inputQuestionTitle = 'something-really-hard';
+  const parameters = [
+    {
+      description: 'title input control when text is entered', controlName: 'title',
+      cssSelector: '#mtdj__question-auth-input-title input', inputValue: 'something-really-hard'
+    },
+    {
+      description: 'topic input control when text is entered', controlName: 'parentTopicTitle',
+      cssSelector: '#mtdj__question-auth-input-topic input', inputValue: 'something-really-hard'
+    },
+    {
+      description: 'body input control when text is entered', controlName: 'body',
+      cssSelector: '#mtdj__question-auth-input-body textarea', inputValue: 'some quqestion'
+    },
+    {
+      description: 'sampleAnswer input control when text is entered', controlName: 'sampleAnswer',
+      cssSelector: '#mtdj__question-auth-input-sample_answer textarea', inputValue: 'some sample answer'
+    }
+  ];
+  parameters.forEach(({ description, cssSelector, inputValue, controlName }) => {
+    it(`should update the value of the ${description}`, () => {
+      const inputFormElement = fixture.debugElement.query(By.css(cssSelector));
+      const inputQuestionTitle = inputValue;
 
-    inputFormElement.nativeElement.value = inputQuestionTitle;
-    inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
+      inputFormElement.nativeElement.value = inputQuestionTitle;
+      inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
 
-    expect(fixture.componentInstance.newQuestionForm.controls.title.value).toEqual(inputQuestionTitle);
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);
+    });
   });
 
   afterEach(() => {

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -136,7 +136,7 @@ describe('QuestionAuthoringPageComponent', () => {
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].valid).toBe(true);
     });
 
-    it('should allow the length of the question title to be up to 64 chars', () => {
+    it('should show an error if the question title is more than 64 chars', () => {
       const controlName = 'title';
       const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));
       const inputQuestionTitle = 'a question title that is very exactly sixty-four characters long';

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -91,6 +91,22 @@ describe('QuestionAuthoringPageComponent', () => {
     {
       description: 'hint3 input control when text is entered', controlName: 'hint3',
       cssSelector: '#mtdj__question-auth-input-hint3 input', inputValue: 'some hint'
+    },
+    {
+      description: 'option1 input control when text is entered', controlName: 'option1',
+      cssSelector: '#mtdj__question-auth-input-option1 input', inputValue: 'some option'
+    },
+    {
+      description: 'option2 input control when text is entered', controlName: 'option2',
+      cssSelector: '#mtdj__question-auth-input-option2 input', inputValue: 'some option'
+    },
+    {
+      description: 'option3 input control when text is entered', controlName: 'option3',
+      cssSelector: '#mtdj__question-auth-input-option3 input', inputValue: 'some option'
+    },
+    {
+      description: 'option4 input control when text is entered', controlName: 'option4',
+      cssSelector: '#mtdj__question-auth-input-option4 input', inputValue: 'some option'
     }
   ];
   parameters.forEach(({ description, cssSelector, inputValue, controlName }) => {
@@ -105,7 +121,12 @@ describe('QuestionAuthoringPageComponent', () => {
     });
   });
 
+  //TODO: Write sepearate test case for select option: https://stackoverflow.com/questions/5678210/select-dropdown-menu-option-with-javascript
+
+  let a = 0;
   afterEach(() => {
+    a++;
+    console.log(`I run for the ${a}st/th time`);
     TestBed.resetTestingModule();
   });
 

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -144,8 +144,15 @@ describe('QuestionAuthoringPageComponent', () => {
       inputFormElement.nativeElement.value = longerQuestionTitle;
       inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
 
+      fixture.detectChanges();
+
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(longerQuestionTitle);
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].invalid).toBe(true);
+
+      // TODO: #41 Test rendering of clarity validation error in unit tests
+      /*
+            const errorDisplayElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title clr-control-error'));
+            expect(errorDisplayElement.nativeElement.value).toMatch(/is a required field/); */
     });
   });
 

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -154,6 +154,7 @@ describe('QuestionAuthoringPageComponent', () => {
 
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(longerQuestionTitle);
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].invalid).toBe(true);
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].errors.maxlength).toBeTruthy();
 
       // TODO: #41 Test rendering of clarity validation error in unit tests
       /*
@@ -174,6 +175,8 @@ describe('QuestionAuthoringPageComponent', () => {
       // Then
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].invalid).toBe(true);
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].errors.required).toBeTruthy();
+
     });
   });
 

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -75,6 +75,22 @@ describe('QuestionAuthoringPageComponent', () => {
     {
       description: 'sampleAnswer input control when text is entered', controlName: 'sampleAnswer',
       cssSelector: '#mtdj__question-auth-input-sample_answer textarea', inputValue: 'some sample answer'
+    },
+    {
+      description: 'answer input control when text is entered', controlName: 'answer',
+      cssSelector: '#mtdj__question-auth-input-answer textarea', inputValue: 'some correct answer'
+    },
+    {
+      description: 'hint1 input control when text is entered', controlName: 'hint1',
+      cssSelector: '#mtdj__question-auth-input-hint1 input', inputValue: 'some hint'
+    },
+    {
+      description: 'hint2 input control when text is entered', controlName: 'hint2',
+      cssSelector: '#mtdj__question-auth-input-hint2 input', inputValue: 'some hint'
+    },
+    {
+      description: 'hint3 input control when text is entered', controlName: 'hint3',
+      cssSelector: '#mtdj__question-auth-input-hint3 input', inputValue: 'some hint'
     }
   ];
   parameters.forEach(({ description, cssSelector, inputValue, controlName }) => {

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -154,6 +154,21 @@ describe('QuestionAuthoringPageComponent', () => {
             const errorDisplayElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title clr-control-error'));
             expect(errorDisplayElement.nativeElement.value).toMatch(/is a required field/); */
     });
+
+    it('should show an error if the question title is empty', () => {
+      // Given
+      const controlName = 'title';
+      const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));
+
+      // When
+      const inputQuestionTitle = '';
+      inputFormElement.nativeElement.value = inputQuestionTitle;
+      inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
+
+      // Then
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].invalid).toBe(true);
+    });
   });
 
 

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -130,7 +130,7 @@ describe('QuestionAuthoringPageComponent', () => {
     });
   });
 
-  describe('Input Validation', () => {
+  describe('Question Title Validation', () => {
     it('should allow a new question title that also meets the 64 chars length restriction', () => {
       const controlName = 'title';
       const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -38,7 +38,8 @@ describe('QuestionAuthoringPageComponent', () => {
       .overrideComponent(QuestionAuthoringPageComponent, {
         set: {
           providers: [
-            { provide: QuestionService, useValue: questionServiceStub }
+            { provide: QuestionService, useValue: questionServiceStub },
+            { provide: QuestionTitleValidator }
           ]
         }
       })
@@ -132,10 +133,11 @@ describe('QuestionAuthoringPageComponent', () => {
   });
 
   describe('Input Validation', () => {
-    it('should allow the length of the question title to be up to 64 chars', () => {
+    it('should allow a new question title that also meets the 64 chars length restriction', () => {
       const controlName = 'title';
       const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));
       const inputQuestionTitle = 'a question title that is very exactly sixty-four characters long';
+      questionServiceStub.getQuestionWithTitle.returns(of(null));
 
       inputFormElement.nativeElement.value = inputQuestionTitle;
       inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -74,10 +74,6 @@ describe('QuestionAuthoringPageComponent', () => {
   describe('Input controls', () => {
     const parameters = [
       {
-        description: 'title input control when text is entered', controlName: 'title',
-        cssSelector: '#mtdj__question-auth-input-title input', inputValue: 'something-really-hard'
-      },
-      {
         description: 'topic input control when text is entered', controlName: 'parentTopicTitle',
         cssSelector: '#mtdj__question-auth-input-topic input', inputValue: 'something-really-hard'
       },

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -14,6 +14,8 @@ import { QuestionAuthoringPageComponent } from './question-authoring-page.compon
 import { MtdgFooterComponent } from '../../mtdg-footer/mtdg-footer.component';
 import { MtdjHeaderComponent } from '../../mtdj-header/mtdj-header.component';
 import { TopicDto } from 'src/app/models/topic-dto';
+import { QuestionDto } from 'src/app/models/question-dto';
+import { QuestionTitleValidator } from './question-title.validator';
 
 
 describe('QuestionAuthoringPageComponent', () => {
@@ -176,7 +178,26 @@ describe('QuestionAuthoringPageComponent', () => {
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].invalid).toBe(true);
       expect(fixture.componentInstance.newQuestionForm.controls[controlName].errors.required).toBeTruthy();
+    });
 
+    it('should show an error if the question title is already taken ', () => {
+      // Given
+      const controlName = 'title';
+      const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));
+      const inputQuestionTitle = 'title-that-is-already-taken';
+      questionServiceStub.getQuestionWithTitle.returns(of(
+        new QuestionDto({ title: inputQuestionTitle, parentTopicTitle: 'something' })));
+
+      // When
+      inputFormElement.nativeElement.value = inputQuestionTitle;
+      inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
+
+      // Then
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].value).toEqual(inputQuestionTitle);
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].invalid).toBe(true);
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].errors.titleAlreadyExists).toBeTruthy();
+      expect(fixture.componentInstance.newQuestionForm.controls[controlName].errors.titleAlreadyExists.errorMessage)
+        .toMatch(`a question with title "${inputQuestionTitle}" already exists`);
     });
   });
 

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -1,23 +1,29 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { QuestionAuthoringPageComponent } from './question-authoring-page.component';
-import { MtdgFooterComponent } from '../../mtdg-footer/mtdg-footer.component';
-import { MtdjHeaderComponent } from '../../mtdj-header/mtdj-header.component';
 import { ClarityModule } from '@clr/angular';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { KatexModule } from 'ng-katex';
-import { QuestionService } from 'src/app/services/question.service';
-import { QuestionServiceStub } from 'src/testing/question.service.stub';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
+import { createStubInstance, SinonStubbedInstance } from 'sinon';
+import { of } from 'rxjs';
+
+import { QuestionService } from 'src/app/services/question.service';
+import { QuestionServiceStub } from 'src/testing/question.service.stub';
+import { QuestionAuthoringPageComponent } from './question-authoring-page.component';
+import { MtdgFooterComponent } from '../../mtdg-footer/mtdg-footer.component';
+import { MtdjHeaderComponent } from '../../mtdj-header/mtdj-header.component';
+import { TopicDto } from 'src/app/models/topic-dto';
 
 
 describe('QuestionAuthoringPageComponent', () => {
   let component: QuestionAuthoringPageComponent;
   let fixture: ComponentFixture<QuestionAuthoringPageComponent>;
+  let questionServiceStub: SinonStubbedInstance<QuestionService>;
 
   beforeEach(async(() => {
+    questionServiceStub = createStubInstance(QuestionService);
+    questionServiceStub.getTopics.returns(of([TopicDto.createDtoWithNonEmptyFields()]));
     TestBed.configureTestingModule({
       declarations: [QuestionAuthoringPageComponent, MtdgFooterComponent, MtdjHeaderComponent],
       imports: [
@@ -30,7 +36,7 @@ describe('QuestionAuthoringPageComponent', () => {
       .overrideComponent(QuestionAuthoringPageComponent, {
         set: {
           providers: [
-            { provide: QuestionService, useValue: QuestionServiceStub }
+            { provide: QuestionService, useValue: questionServiceStub }
           ]
         }
       })

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -50,6 +50,10 @@ describe('QuestionAuthoringPageComponent', () => {
     fixture = TestBed.createComponent(QuestionAuthoringPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    // Setup all scenarios so that question title validation returns no errors
+    // unless otherwise specified
+    questionServiceStub.getQuestionWithTitle.returns(of(null));
   });
 
   it('should create', () => {
@@ -136,7 +140,6 @@ describe('QuestionAuthoringPageComponent', () => {
       const controlName = 'title';
       const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));
       const inputQuestionTitle = 'a question title that is very exactly sixty-four characters long';
-      questionServiceStub.getQuestionWithTitle.returns(of(null));
 
       inputFormElement.nativeElement.value = inputQuestionTitle;
       inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -59,6 +59,16 @@ describe('QuestionAuthoringPageComponent', () => {
     expect(component.onSubmit).toHaveBeenCalledTimes(1);
   });
 
+  it('should update the value of the question title control when text is entered', () => {
+    const inputFormElement = fixture.debugElement.query(By.css('#mtdj__question-auth-input-title input'));
+    const inputQuestionTitle = 'something-really-hard';
+
+    inputFormElement.nativeElement.value = inputQuestionTitle;
+    inputFormElement.nativeElement.dispatchEvent(new InputEvent('input'));
+
+    expect(fixture.componentInstance.newQuestionForm.controls.title.value).toEqual(inputQuestionTitle);
+  });
+
   afterEach(() => {
     TestBed.resetTestingModule();
   });

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
@@ -31,13 +31,16 @@ export class QuestionAuthoringPageComponent implements OnInit {
     const boundValidatorFunction: (ctrl: AbstractControl) => Observable<ValidationErrors> = this
       .questionTitleValidator.validate.bind(this.questionTitleValidator);
     this.newQuestionForm = new FormGroup({
-      title: new FormControl('', [
-        Validators.required,
-        Validators.maxLength(this.maxQuestionTitleLength)
-      ],
-        [
+      title: new FormControl('', {
+        validators: [
+          Validators.required,
+          Validators.maxLength(this.maxQuestionTitleLength)
+        ],
+        updateOn: 'blur',
+        asyncValidators: [
           boundValidatorFunction
-        ]),
+        ]
+      }),
       body: new FormControl('', Validators.required),
       sampleAnswer: new FormControl(''),
       hint1: new FormControl(''),

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
@@ -15,13 +15,13 @@ import { Difficulty } from 'src/app/models/question_difficulty';
   styleUrls: ['./question-authoring-page.component.scss']
 })
 export class QuestionAuthoringPageComponent implements OnInit {
-  submitted = false;
-  questionExists = false;
+  private maxQuestionTitleLength = 64;
   difficulty: Difficulty[] = Object.keys(Difficulty).map(each => each as Difficulty);
-  validateOptions = true;
-  disabled = false;
+
   newQuestionForm: FormGroup = new FormGroup({
-    title: new FormControl('', Validators.required),
+    title: new FormControl('', [
+      Validators.required, Validators.maxLength(this.maxQuestionTitleLength)
+    ]),
     body: new FormControl('', Validators.required),
     sampleAnswer: new FormControl(''),
     hint1: new FormControl(''),
@@ -52,39 +52,40 @@ export class QuestionAuthoringPageComponent implements OnInit {
 
   onSubmit() {
 
-    const question = new QuestionDto({
-      title: this.newQuestionForm.controls.title.value,
-      questionBody: this.newQuestionForm.controls.body.value,
-      sampleAnswer: this.newQuestionForm.controls.sampleAnswer.value,
-      hints: [this.newQuestionForm.controls.hint1.value, this.newQuestionForm
-        .controls.hint1.value, this.newQuestionForm.controls.hint3.value],
-      answer: this.newQuestionForm.controls.answer.value,
-      successRate: 0,
-      difficulty: this.newQuestionForm.controls.difficulty.value,
-      parentTopicTitle: this.newQuestionForm.controls.parentTopicTitle.value,
-      questionAnswerOptions: [this.newQuestionForm.controls.option1.value,
-      this.newQuestionForm.controls.option2.value,
-      this.newQuestionForm.controls.option3.value,
-      this.newQuestionForm.controls.option4.value],
-      solved: false
-    });
+    /*     const question = new QuestionDto({
+          title: this.newQuestionForm.controls.title.value,
+          questionBody: this.newQuestionForm.controls.body.value,
+          sampleAnswer: this.newQuestionForm.controls.sampleAnswer.value,
+          hints: [this.newQuestionForm.controls.hint1.value, this.newQuestionForm
+            .controls.hint1.value, this.newQuestionForm.controls.hint3.value],
+          answer: this.newQuestionForm.controls.answer.value,
+          successRate: 0,
+          difficulty: this.newQuestionForm.controls.difficulty.value,
+          parentTopicTitle: this.newQuestionForm.controls.parentTopicTitle.value,
+          questionAnswerOptions: [this.newQuestionForm.controls.option1.value,
+          this.newQuestionForm.controls.option2.value,
+          this.newQuestionForm.controls.option3.value,
+          this.newQuestionForm.controls.option4.value],
+          solved: false
+        });
 
-    this.validateOptions = this.customOptionsValidator(question.questionAnswerOptions);
-    let notFound: boolean;
-    this.questionService.getQuestionWithTitle(question.title).pipe(map(questions => notFound = questions.title === null));
-    if (notFound === true) {
-      this.questionExists = true;
-    }
-    if (this.validateOptions && !this.questionExists) {
-      // connect to azure queue store here
-      this.submitted = true;
-    }
+        this.validateOptions = this.customOptionsValidator(question.questionAnswerOptions);
+        let notFound: boolean;
+        this.questionService.getQuestionWithTitle(question.title).pipe(map(questions => notFound = questions.title === null));
+        if (notFound === true) {
+          this.questionExists = true;
+        }
+        if (this.validateOptions && !this.questionExists) {
+          // connect to azure queue store here
+          this.submitted = true;
+        } */
 
     // add web security
   }
-  customOptionsValidator(options: string[]) {
-    return !(options[0] !== '' && options[1] === '') && !(options[0] === '' &&
-      (options[1] !== '' || options[2] !== '' || options[3] !== ''));
-  }
+
+  /*   customOptionsValidator(options: string[]) {
+      return !(options[0] !== '' && options[1] === '') && !(options[0] === '' &&
+        (options[1] !== '' || options[2] !== '' || options[3] !== ''));
+    } */
 
 }

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
@@ -5,6 +5,7 @@ import { QuestionService } from 'src/app/services/question.service';
 import { QuestionDto } from 'src/app/models/question-dto';
 import { map } from 'rxjs/operators';
 import { Topic } from 'src/app/models/topic';
+import { Difficulty } from 'src/app/models/question_difficulty';
 
 
 
@@ -16,7 +17,7 @@ import { Topic } from 'src/app/models/topic';
 export class QuestionAuthoringPageComponent implements OnInit {
   submitted = false;
   questionExists = false;
-  difficulty: string[] = ['Easy', 'Medium', 'Hard'];
+  difficulty: Difficulty[] = Object.keys(Difficulty).map(each => each as Difficulty);
   validateOptions = true;
   disabled = false;
   newQuestionForm: FormGroup = new FormGroup({

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
@@ -6,6 +6,7 @@ import { QuestionDto } from 'src/app/models/question-dto';
 import { map } from 'rxjs/operators';
 import { Topic } from 'src/app/models/topic';
 import { Difficulty } from 'src/app/models/question_difficulty';
+import { QuestionTitleValidator } from './question-title.validator';
 
 
 
@@ -16,29 +17,33 @@ import { Difficulty } from 'src/app/models/question_difficulty';
 })
 export class QuestionAuthoringPageComponent implements OnInit {
   private maxQuestionTitleLength = 64;
-  difficulty: Difficulty[] = Object.keys(Difficulty).map(each => each as Difficulty);
+  private questionTitleValidator: QuestionTitleValidator;
 
-  newQuestionForm: FormGroup = new FormGroup({
-    title: new FormControl('', [
-      Validators.required, Validators.maxLength(this.maxQuestionTitleLength)
-    ]),
-    body: new FormControl('', Validators.required),
-    sampleAnswer: new FormControl(''),
-    hint1: new FormControl(''),
-    hint2: new FormControl(''),
-    hint3: new FormControl(''),
-    difficulty: new FormControl('', Validators.required),
-    parentTopicTitle: new FormControl('', Validators.required),
-    option1: new FormControl(''),
-    option2: new FormControl(''),
-    option3: new FormControl(''),
-    option4: new FormControl(''),
-    answer: new FormControl('', Validators.required)
-  });
+  difficulty: Difficulty[] = Object.keys(Difficulty).map(each => each as Difficulty);
+  newQuestionForm: FormGroup;
   topics$: any;
 
   constructor(private questionService: QuestionService) {
-
+    // this.questionTitleValidator = new QuestionTitleValidator(questionService);
+    this.newQuestionForm = new FormGroup({
+      title: new FormControl('', [
+        Validators.required,
+        Validators.maxLength(this.maxQuestionTitleLength)/* ,
+        this.questionTitleValidator.validate */
+      ]),
+      body: new FormControl('', Validators.required),
+      sampleAnswer: new FormControl(''),
+      hint1: new FormControl(''),
+      hint2: new FormControl(''),
+      hint3: new FormControl(''),
+      difficulty: new FormControl('', Validators.required),
+      parentTopicTitle: new FormControl('', Validators.required),
+      option1: new FormControl(''),
+      option2: new FormControl(''),
+      option3: new FormControl(''),
+      option4: new FormControl(''),
+      answer: new FormControl('', Validators.required)
+    });
   }
 
   ngOnInit(): void {

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { FormGroup, FormControl, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
 
 import { QuestionService } from 'src/app/services/question.service';
 import { QuestionDto } from 'src/app/models/question-dto';
@@ -7,6 +7,7 @@ import { map } from 'rxjs/operators';
 import { Topic } from 'src/app/models/topic';
 import { Difficulty } from 'src/app/models/question_difficulty';
 import { QuestionTitleValidator } from './question-title.validator';
+import { Observable } from 'rxjs';
 
 
 
@@ -23,13 +24,19 @@ export class QuestionAuthoringPageComponent implements OnInit {
   topics$: any;
 
   constructor(private questionService: QuestionService, private questionTitleValidator: QuestionTitleValidator) {
+    /* Angular calls the async validator from some context where "this" does not point to
+     * the instance of the questionTitleValidator bound here. This needs to be done
+     * explicitly.
+     */
+    const boundValidatorFunction: (ctrl: AbstractControl) => Observable<ValidationErrors> = this
+      .questionTitleValidator.validate.bind(this.questionTitleValidator);
     this.newQuestionForm = new FormGroup({
       title: new FormControl('', [
         Validators.required,
         Validators.maxLength(this.maxQuestionTitleLength)
       ],
         [
-          this.questionTitleValidator.validate.bind(this.questionTitleValidator)
+          boundValidatorFunction
         ]),
       body: new FormControl('', Validators.required),
       sampleAnswer: new FormControl(''),

--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.ts
@@ -17,20 +17,20 @@ import { QuestionTitleValidator } from './question-title.validator';
 })
 export class QuestionAuthoringPageComponent implements OnInit {
   private maxQuestionTitleLength = 64;
-  private questionTitleValidator: QuestionTitleValidator;
 
   difficulty: Difficulty[] = Object.keys(Difficulty).map(each => each as Difficulty);
   newQuestionForm: FormGroup;
   topics$: any;
 
-  constructor(private questionService: QuestionService) {
-    // this.questionTitleValidator = new QuestionTitleValidator(questionService);
+  constructor(private questionService: QuestionService, private questionTitleValidator: QuestionTitleValidator) {
     this.newQuestionForm = new FormGroup({
       title: new FormControl('', [
         Validators.required,
-        Validators.maxLength(this.maxQuestionTitleLength)/* ,
-        this.questionTitleValidator.validate */
-      ]),
+        Validators.maxLength(this.maxQuestionTitleLength)
+      ],
+        [
+          this.questionTitleValidator.validate.bind(this.questionTitleValidator)
+        ]),
       body: new FormControl('', Validators.required),
       sampleAnswer: new FormControl(''),
       hint1: new FormControl(''),

--- a/src/app/components/practice/question-authoring-page/question-title.validator.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-title.validator.spec.ts
@@ -1,0 +1,64 @@
+import { QuestionTitleValidator } from './question-title.validator';
+import { TestBed } from '@angular/core/testing';
+import { QuestionService } from 'src/app/services/question.service';
+import { createStubInstance, SinonStubbedInstance } from 'sinon';
+import { FormControl, ValidationErrors } from '@angular/forms';
+import { Observable, of, throwError } from 'rxjs';
+import { QuestionDto } from 'src/app/models/question-dto';
+import { QuestionServiceError } from 'src/app/services/question-service.error';
+
+describe('QuestionTitleValidator', () => {
+  let questionTitleValidator: QuestionTitleValidator;
+  let questionServiceStub: SinonStubbedInstance<QuestionService>;
+
+  beforeEach(() => {
+    questionServiceStub = createStubInstance(QuestionService);
+    TestBed.configureTestingModule({
+      // Provide both the service-to-test and its (spy) dependency
+      providers: [
+        QuestionTitleValidator,
+        { provide: QuestionService, useValue: questionServiceStub }
+      ]
+    });
+    questionTitleValidator = TestBed.inject(QuestionTitleValidator);
+    // TestBed.inject(QuestionService);
+  });
+
+  it('should return null if the value in the control is not an existing question title', () => {
+    const testControl = new FormControl('an-unknown-title');
+    questionServiceStub.getQuestionWithTitle.returns(of(null));
+
+    const validationResult = questionTitleValidator.validate(testControl) as Observable<ValidationErrors>;
+    validationResult.subscribe({
+      next: (result) => expect(result).toBe(null, `validation result: ${result} is not null`),
+    });
+  });
+
+  it('should return an object with a titleAlreadyExists property if the value in control is an existing question title', () => {
+    const testControl = new FormControl('an-existing-title');
+    questionServiceStub.getQuestionWithTitle.returns(
+      of(new QuestionDto({ title: testControl.value, parentTopicTitle: 'something' })));
+
+    const validationResult = questionTitleValidator.validate(testControl) as Observable<ValidationErrors>;
+    validationResult.subscribe({
+      next: (result) => expect(result.titleAlreadyExists.errorMessage).toMatch(
+        `a question with title "${testControl.value}" already exists`),
+    });
+  });
+
+  it('should return an object with a titleAlreadyExists property if the query via QuestionService fails', () => {
+    const testControl = new FormControl('an-existing-title');
+    questionServiceStub.getQuestionWithTitle.callsFake(() => throwError(new QuestionServiceError('some error')));
+
+    const validationResult = questionTitleValidator.validate(testControl) as Observable<ValidationErrors>;
+    validationResult.subscribe({
+      next: (result) => expect(result.titleAlreadyExists.errorMessage).toMatch(
+        `the question title "${testControl.value}" could not be verified at this time, please try again later`),
+      error: (error => fail(`the error, :${error.message} was unexpected`))
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+});

--- a/src/app/components/practice/question-authoring-page/question-title.validator.ts
+++ b/src/app/components/practice/question-authoring-page/question-title.validator.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { AsyncValidator, AbstractControl, ValidationErrors } from '@angular/forms';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { QuestionService } from 'src/app/services/question.service';
+
+@Injectable({ providedIn: 'root' })
+export class QuestionTitleValidator implements AsyncValidator {
+  constructor(private questionService: QuestionService) { }
+
+  validate(
+    ctrl: AbstractControl
+  ): Promise<ValidationErrors | null> | Observable<ValidationErrors | null> {
+    return this.questionService.getQuestionWithTitle(ctrl.value).pipe(
+      map((questionServiceResponse) => {
+        if (questionServiceResponse && (questionServiceResponse.title === ctrl.value)) {
+          return this.createQuestionTitleValidationError(`a question with title "${ctrl.value}" already exists`);
+        }
+        return null;
+      }),
+      catchError((error) => {
+        // log this error appropriately
+        return of(this.createQuestionTitleValidationError(
+          `the question title "${ctrl.value}" could not be verified at this time, please try again later`));
+      })
+    );
+  }
+
+  private createQuestionTitleValidationError(errorMessage: string) {
+    return {
+      titleAlreadyExists: {
+        errorMessage
+      }
+    };
+  }
+}

--- a/src/app/models/question-dto.ts
+++ b/src/app/models/question-dto.ts
@@ -1,74 +1,75 @@
 export class QuestionDto {
-    public readonly title: string;
-    public readonly questionBody: string;
-    public readonly sampleAnswer: string;
-    public readonly hints: string[];
-    public readonly successRate: number;
-    public readonly difficulty: string;
-    public readonly parentTopicTitle: string;
-    public readonly questionAnswerOptions: string[];
-    public readonly answer: string;
-    public readonly solved: boolean;
+  public readonly title: string;
+  public readonly questionBody: string;
+  public readonly sampleAnswer: string;
+  public readonly hints: string[];
+  public readonly successRate: number;
+  public readonly difficulty: string;
+  public readonly parentTopicTitle: string;
+  public readonly questionAnswerOptions: string[];
+  public readonly answer: string;
+  public readonly solved: boolean;
+  public readonly imageUrl: string;
 
-    public constructor({
-        title,
-        questionBody,
-        sampleAnswer,
-        hints,
-        answer,
-        successRate,
-        difficulty,
-        parentTopicTitle,
-        questionAnswerOptions,
-        solved
-    }: {
-        title: string,
-        questionBody: string,
-        sampleAnswer: string,
-        hints: string[],
-        answer: string,
-        successRate: number,
-        difficulty: string,
-        parentTopicTitle: string,
-        questionAnswerOptions: string[],
-        solved: boolean
-    }) {
-        this.title = title;
-        this.questionBody = questionBody;
-        this.sampleAnswer = sampleAnswer;
-        this.hints = hints;
-        this.answer = answer;
-        this.successRate = successRate;
-        this.difficulty = difficulty;
-        this.questionAnswerOptions = questionAnswerOptions;
-        this.parentTopicTitle = parentTopicTitle;
-        this.solved = solved;
-    }
+  public constructor({
+    title,
+    questionBody,
+    sampleAnswer,
+    hints,
+    answer,
+    successRate,
+    difficulty,
+    parentTopicTitle,
+    questionAnswerOptions,
+    solved
+  }: {
+    title: string,
+    questionBody: string,
+    sampleAnswer: string,
+    hints: string[],
+    answer: string,
+    successRate: number,
+    difficulty: string,
+    parentTopicTitle: string,
+    questionAnswerOptions: string[],
+    solved: boolean
+  }) {
+    this.title = title;
+    this.questionBody = questionBody;
+    this.sampleAnswer = sampleAnswer;
+    this.hints = hints;
+    this.answer = answer;
+    this.successRate = successRate;
+    this.difficulty = difficulty;
+    this.questionAnswerOptions = questionAnswerOptions;
+    this.parentTopicTitle = parentTopicTitle;
+    this.solved = solved;
+  }
 
-    static createDtoWithNonEmptyFields({
-        title = '',
-        questionBody = '',
-        sampleAnswer = '',
-        hints = [''],
-        answer = '',
-        successRate = 0,
-        difficulty = '',
-        parentTopicTitle = '',
-        questionAnswerOptions = [''],
-        solved = false
-    } = {}): QuestionDto {
-        return new QuestionDto({
-            title,
-            questionBody,
-            sampleAnswer,
-            hints,
-            answer,
-            successRate,
-            difficulty,
-            parentTopicTitle,
-            questionAnswerOptions,
-            solved
-        });
-    }
+  static createDtoWithNonEmptyFields({
+    title = '',
+    questionBody = '',
+    sampleAnswer = '',
+    hints = [''],
+    answer = '',
+    successRate = 0,
+    difficulty = '',
+    parentTopicTitle = '',
+    questionAnswerOptions = [''],
+    solved = false
+  } = {}): QuestionDto {
+    return new QuestionDto({
+      title,
+      questionBody,
+      sampleAnswer,
+      hints,
+      answer,
+      successRate,
+      difficulty,
+      parentTopicTitle,
+      questionAnswerOptions,
+      solved
+    });
+  }
 
 }

--- a/src/app/models/question-dto.ts
+++ b/src/app/models/question-dto.ts
@@ -14,16 +14,16 @@ export class QuestionDto {
   public readonly imageUrl: string;
 
   public constructor({
-    title,
-    questionBody,
-    sampleAnswer,
-    hints,
-    answer,
-    successRate,
-    difficulty,
+    title = '',
+    questionBody = '',
+    sampleAnswer = '',
+    hints = [],
+    answer = '',
+    successRate = 0,
+    difficulty = Difficulty.Easy,
     parentTopicTitle,
-    questionAnswerOptions,
-    solved
+    questionAnswerOptions = [],
+    solved = false
   }: {
     title: string,
     questionBody: string,

--- a/src/app/models/question-dto.ts
+++ b/src/app/models/question-dto.ts
@@ -14,7 +14,7 @@ export class QuestionDto {
   public readonly imageUrl: string;
 
   public constructor({
-    title = '',
+    title,
     questionBody = '',
     sampleAnswer = '',
     hints = [],
@@ -26,15 +26,15 @@ export class QuestionDto {
     solved = false
   }: {
     title: string,
-    questionBody: string,
-    sampleAnswer: string,
-    hints: string[],
-    answer: string,
-    successRate: number,
-    difficulty: Difficulty,
+    questionBody?: string,
+    sampleAnswer?: string,
+    hints?: string[],
+    answer?: string,
+    successRate?: number,
+    difficulty?: Difficulty,
     parentTopicTitle: string,
-    questionAnswerOptions: string[],
-    solved: boolean
+    questionAnswerOptions?: string[],
+    solved?: boolean
   }) {
     this.title = title;
     this.questionBody = questionBody;

--- a/src/app/models/question-dto.ts
+++ b/src/app/models/question-dto.ts
@@ -1,10 +1,12 @@
+import { Difficulty } from './question_difficulty';
+
 export class QuestionDto {
   public readonly title: string;
   public readonly questionBody: string;
   public readonly sampleAnswer: string;
   public readonly hints: string[];
   public readonly successRate: number;
-  public readonly difficulty: string;
+  public readonly difficulty: Difficulty;
   public readonly parentTopicTitle: string;
   public readonly questionAnswerOptions: string[];
   public readonly answer: string;
@@ -29,7 +31,7 @@ export class QuestionDto {
     hints: string[],
     answer: string,
     successRate: number,
-    difficulty: string,
+    difficulty: Difficulty,
     parentTopicTitle: string,
     questionAnswerOptions: string[],
     solved: boolean
@@ -53,7 +55,7 @@ export class QuestionDto {
     hints = [''],
     answer = '',
     successRate = 0,
-    difficulty = '',
+    difficulty = null,
     parentTopicTitle = '',
     questionAnswerOptions = [''],
     solved = false

--- a/src/app/models/question.ts
+++ b/src/app/models/question.ts
@@ -1,5 +1,6 @@
 import { QuestionDto } from './question-dto';
 import { convertKebabToSentenceCase } from '../utilities/content-title-formatter';
+import { Difficulty } from './question_difficulty';
 
 export class Question extends QuestionDto {
   public readonly formattedTitle: string;
@@ -25,7 +26,7 @@ export class Question extends QuestionDto {
     hints: string[],
     answer: string,
     successRate: number,
-    difficulty: string,
+    difficulty: Difficulty,
     questionAnswerOptions,
     parentTopicTitle,
     solved: boolean

--- a/src/app/models/question_difficulty.ts
+++ b/src/app/models/question_difficulty.ts
@@ -1,0 +1,5 @@
+export enum Difficulty {
+  Easy = 'Easy',
+  Medium = 'Medium',
+  Difficult = 'Difficult'
+}

--- a/src/app/services/question-service.error.ts
+++ b/src/app/services/question-service.error.ts
@@ -1,0 +1,9 @@
+/**
+ * Error thrown by the QuestionService {@link QuestionService} in the presence of any
+ * unexpected errors from the call to the QuestionService backend.
+ */
+export class QuestionServiceError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/app/services/question.service.spec.ts
+++ b/src/app/services/question.service.spec.ts
@@ -84,8 +84,9 @@ describe('QuestionService', () => {
 
     const checkErrorThrown = <T>(expectedErrorType: GenericErrorType<T>, regexMatchForMessage: RegExp) => {
       return (error: Error) => {
-        expect(error instanceof expectedErrorType).toBe(true);
-        expect(error.message).toMatch(regexMatchForMessage);
+        expect(error instanceof expectedErrorType).toBe(
+          true, `The provided error did not match the expected type ${expectedErrorType.name}`);
+        expect(error.message).toMatch(regexMatchForMessage, `the error message: ${error.message} did not match the expected format`);
       };
     };
 

--- a/src/app/services/question.service.spec.ts
+++ b/src/app/services/question.service.spec.ts
@@ -47,6 +47,30 @@ describe('QuestionService', () => {
     req.flush(expectedQuestionDto);
   });
 
+  it('should return null if question could not be found, i.e. error was 404 ', () => {
+    // Given
+    const questionNameToSearchFor = 'test-question';
+    const expectedQuestionDto = new QuestionDto({ title: questionNameToSearchFor, parentTopicTitle: 'nonsense' });
+
+    // When
+    const questionSearchObservable = questionService.getQuestionWithTitle(questionNameToSearchFor);
+
+    // Then
+    questionSearchObservable.subscribe({
+      next: response => expect(response).toBeNull('the returned object is not null'),
+      error: fail
+    });
+
+    const req = httpTestingController.expectOne(`${
+      environment.apis.questionServiceConsumerEndpoint}/questions/${questionNameToSearchFor
+      }`);
+    expect(req.request.method).toEqual('GET');
+    req.flush(`the specified question ${questionNameToSearchFor} could not be found`, {
+      status: 404,
+      statusText: 'not found'
+    });
+  });
+
   afterEach(() => {
     httpTestingController.verify();
 

--- a/src/app/services/question.service.spec.ts
+++ b/src/app/services/question.service.spec.ts
@@ -73,7 +73,7 @@ describe('QuestionService', () => {
     });
   });
 
-  it('should return a QuestionServiceError if the service returns codes between 400 and 503, excluding 404', () => {
+  it('should throw a QuestionServiceError if the service returns codes between 400 and 503, excluding 404', () => {
     // Given
     const questionNameToSearchFor = 'test-question';
     const expectedQuestionDto = new QuestionDto({ title: questionNameToSearchFor, parentTopicTitle: 'nonsense' });

--- a/src/app/services/question.service.ts
+++ b/src/app/services/question.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Observable, of, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 
 import { environment } from '../../environments/environment';
 import { TopicDto } from '../models/topic-dto';
 import { QuestionDto } from '../models/question-dto';
 import { Difficulty } from '../models/question_difficulty';
-import { catchError } from 'rxjs/operators';
+import { QuestionServiceError } from './question-service.error';
 
 @Injectable({
   providedIn: 'root'
@@ -139,7 +140,7 @@ export class QuestionService {
             if (err.status === 404) {
               return of(null);
             }
-            throwError(err);
+            throw new QuestionServiceError(err.message);
           })
         );
     }

--- a/src/app/services/question.service.ts
+++ b/src/app/services/question.service.ts
@@ -5,6 +5,7 @@ import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 import { TopicDto } from '../models/topic-dto';
 import { QuestionDto } from '../models/question-dto';
+import { Difficulty } from '../models/question_difficulty';
 
 @Injectable({
   providedIn: 'root'
@@ -52,36 +53,36 @@ export class QuestionService {
       questionBody: 'When $a \\ne 0$, the solution of $$(ax^2 + bx + c = 0)$$ is $$x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}.$$',
       sampleAnswer: '42',
       successRate: 0.42,
-      difficulty: 'easy',
+      difficulty: Difficulty.Easy,
       answer: 'false',
       hints: ['try this', 'watch space odyssey'],
       parentTopicTitle: 'something-hard',
       questionAnswerOptions: ['choose me', 'me too', 'que no se te olvide que estoy'],
-      solved : false
+      solved: false
     }),
     new QuestionDto({
       title: 'other-thing-to-try',
       questionBody: '$\\sum_{i=1}^nx_i$',
       sampleAnswer: '42',
       successRate: 0.817563,
-      difficulty: 'easy',
+      difficulty: Difficulty.Easy,
       answer: 'false',
       hints: ['try this', 'watch space odyssey'],
       parentTopicTitle: 'something-hard',
       questionAnswerOptions: ['choose me', 'me too', 'que no se te olvide que estoy'],
-      solved : false
+      solved: false
     }),
     new QuestionDto({
       title: 'final-on-the-list',
       questionBody: 'something quite complex',
       sampleAnswer: '42',
       successRate: 0.2,
-      difficulty: 'easy',
+      difficulty: Difficulty.Easy,
       answer: 'false',
       hints: ['try this', 'watch space odyssey'],
       parentTopicTitle: 'something-hard',
       questionAnswerOptions: ['choose me', 'me too', 'que no se te olvide que estoy'],
-      solved : false
+      solved: false
     })
   ];
 
@@ -89,7 +90,7 @@ export class QuestionService {
     if (environment.name === 'default') {
       return this.http.get<QuestionDto[]>(`${
         environment.apis.questionServiceConsumerEndpoint
-      }/topics/${topicTitle}/questions`);
+        }/topics/${topicTitle}/questions`);
     }
 
     /* Return a prestashed response when deployed
@@ -102,7 +103,7 @@ export class QuestionService {
     if (environment.name === 'default') {
       return this.http.get<TopicDto[]>(`${
         environment.apis.questionServiceConsumerEndpoint
-      }/topics`);
+        }/topics`);
     }
 
     /* Return a prestashed response when deployed
@@ -115,7 +116,7 @@ export class QuestionService {
     if (environment.name === 'default') {
       return this.http.get<TopicDto>(`${
         environment.apis.questionServiceConsumerEndpoint
-      }/topics/${topicTitle}`);
+        }/topics/${topicTitle}`);
     }
     /* Return a prestashed response when deployed
      * until the question service api is ready
@@ -131,7 +132,7 @@ export class QuestionService {
     if (environment.name === 'default') {
       return this.http.get<QuestionDto>(`${
         environment.apis.questionServiceConsumerEndpoint
-      }/questions/${questionTitle}`);
+        }/questions/${questionTitle}`);
     }
     /* Return a prestashed response when deployed
      * until the question service api is ready
@@ -143,10 +144,10 @@ export class QuestionService {
       hints: ['try this first', 'if this doesn\'t help, tough'],
       answer: 'false',
       successRate: 0.4,
-      difficulty: 'simple',
+      difficulty: Difficulty.Easy,
       parentTopicTitle: 'something-hard',
       questionAnswerOptions: ['choose me', 'me too', 'que no se te olvide que estoy'],
-      solved : false
+      solved: false
     }));
   }
 }

--- a/src/app/utilities/generic-error.interface.ts
+++ b/src/app/utilities/generic-error.interface.ts
@@ -1,5 +1,0 @@
-/**
- * A generic error interface used for performing assertions on types
- * of errors thrown from services.
- */
-export type GenericErrorInterface<T> = new (message?: string) => T;

--- a/src/app/utilities/generic-error.interface.ts
+++ b/src/app/utilities/generic-error.interface.ts
@@ -1,0 +1,5 @@
+/**
+ * A generic error interface used for performing assertions on types
+ * of errors thrown from services.
+ */
+export type GenericErrorInterface<T> = new (message?: string) => T;

--- a/src/app/utilities/generic-error.type.ts
+++ b/src/app/utilities/generic-error.type.ts
@@ -1,0 +1,6 @@
+/**
+ * A generic error type used for performing assertions on types
+ * of errors thrown from services. Assert errors by comparing the
+ * call signature of the error's prototype.
+ */
+export type GenericErrorType<T> = new (message?: string) => T;


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

- Use Clarity Design error and helper text capability on Question Authoring Form
- Setup custom validator for question title
- Add unit tests for QuestionService methods used for question title validation
- Setup preview area for authored questions (intent is to pre-render the math jax for the user to confirm they are happy with it prior to submission)

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

- Test the code
<!-- Add steps to run the tests suite and/or manually test -->
The new functionality is covered by unit tests that can be found in the question-authoring-page.component.spec.ts. Any components required to enable the functionality also have associated unit tests.

```sh
npm test
```

## What to Check

Verify that the following are valid

- 35 unit tests should pass with 4 skipped


## Other Information
Finally a test can be done via the browser by starting up the app (`npm start`) navigating to the authoring page feature area and typing a question title. If the title: "try-me-first" is used, an error validation message will come up.


<!-- Add any other helpful information that may be needed here. -->
