### PR TITLE
Ft66 - Fix ignored assertions in asynchronous unit tests

### DIFF
--- a/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring-page.component.spec.ts
@@ -158,7 +158,7 @@ describe('QuestionAuthoringPageComponent', () => {
   });
 
   describe('Question Title Validation', () => {
-    it('should allow a new question title that also meets the 64 chars length restriction', () => {
+    it('should allow a new question title that also meets the 64 chars length restriction', async(() => {
       const controlName = 'title';
       const inputFormElement = fixture.debugElement.query(
         By.css('#mtdj__question-auth-input-title input')
@@ -177,7 +177,7 @@ describe('QuestionAuthoringPageComponent', () => {
       expect(
         fixture.componentInstance.newQuestionForm.controls[controlName].valid
       ).toBe(true);
-    });
+    }));
 
     it('should show an error if the question title is more than 64 chars', () => {
       const controlName = 'title';
@@ -248,7 +248,7 @@ describe('QuestionAuthoringPageComponent', () => {
       expect(errorDisplayElement.textContent).toMatch(/is a required field/);
     });
 
-    it('should show an error if the question title is already taken ', () => {
+    it('should show an error if the question title is already taken ', async(() => {
       // Given
       const controlName = 'title';
       const inputFormElement = fixture.debugElement.query(
@@ -291,7 +291,7 @@ describe('QuestionAuthoringPageComponent', () => {
       .withContext(`expected to find only one error element but found ${errorElements.length}`)
       .toEqual(1);
       expect(errorDisplayElement.textContent).toMatch(/already exists/);
-    });
+    }));
   });
 
   describe('Question Form', () => {

--- a/src/app/components/practice/question-authoring-page/question-authoring.guard.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-authoring.guard.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { async, TestBed } from '@angular/core/testing';
 
 import { QuestionAuthoringGuard } from './question-authoring.guard';
 import { AuthenticationService } from '../../../services/authentication.service';
@@ -27,7 +27,7 @@ describe('QuestionAuthoringGuard', () => {
   });
 
 
-  it('should allow the org admin user to access authoring page', () => {
+  it('should allow the org admin user to access authoring page', async(() => {
     const user = new User({
       name: 'test',
       permissions: new Set([UserPermission.ORG_ADMIN]),
@@ -37,9 +37,9 @@ describe('QuestionAuthoringGuard', () => {
     guard.canActivate(routeMock, routeStateMock).subscribe((resp) => {
       expect(resp).toEqual(true);
     });
-  });
+  }));
 
-  it('should allow creators user to access authoring page', () => {
+  it('should allow creators user to access authoring page', async(() => {
     const user = new User({
       name: 'test',
       permissions: new Set([UserPermission.CREATOR]),
@@ -49,9 +49,9 @@ describe('QuestionAuthoringGuard', () => {
     guard.canActivate(routeMock, routeStateMock).subscribe((resp) => {
       expect(resp).toEqual(true);
     });
-  });
+  }));
 
-  it('should not allow consumers to access authoring page', () => {
+  it('should not allow consumers to access authoring page', async(() => {
     const user = new User({
       name: 'test',
       permissions: new Set([UserPermission.CONSUMER]),
@@ -61,9 +61,9 @@ describe('QuestionAuthoringGuard', () => {
     guard.canActivate(routeMock, routeStateMock).subscribe((resp) => {
       expect(resp).toEqual(false);
     });
-  });
+  }));
 
-  it('should not allow global admin to access authoring page', () => {
+  it('should not allow global admin to access authoring page', async(() => {
     const user = new User({
       name: 'test',
       permissions: new Set([UserPermission.GLOBAL_ADMIN]),
@@ -73,5 +73,5 @@ describe('QuestionAuthoringGuard', () => {
     guard.canActivate(routeMock, routeStateMock).subscribe((resp) => {
       expect(resp).toEqual(false);
     });
-  });
+  }));
 });

--- a/src/app/components/practice/question-authoring-page/question-title.validator.spec.ts
+++ b/src/app/components/practice/question-authoring-page/question-title.validator.spec.ts
@@ -1,5 +1,5 @@
 import { QuestionTitleValidator } from './question-title.validator';
-import { TestBed } from '@angular/core/testing';
+import { async, TestBed } from '@angular/core/testing';
 import { QuestionService } from 'src/app/services/question.service';
 import { createStubInstance, SinonStubbedInstance } from 'sinon';
 import { FormControl, ValidationErrors } from '@angular/forms';
@@ -24,7 +24,7 @@ describe('QuestionTitleValidator', () => {
     // TestBed.inject(QuestionService);
   });
 
-  it('should return null if the value in the control is not an existing question title', () => {
+  it('should return null if the value in the control is not an existing question title', async(() => {
     const testControl = new FormControl('an-unknown-title');
     questionServiceStub.searchForQuestionBy.returns(of([]));
 
@@ -32,9 +32,9 @@ describe('QuestionTitleValidator', () => {
     validationResult.subscribe({
       next: (result) => expect(result).toBe(null, `validation result: ${result} is not null`),
     });
-  });
+  }));
 
-  it('should return an object with a titleAlreadyExists property if the value in control is an existing question title', () => {
+  it('should return an object with a titleAlreadyExists property if the value in control is an existing question title', async(() => {
     const testControl = new FormControl('an-existing-title');
     questionServiceStub.searchForQuestionBy.returns(
       of([new QuestionDto({ title: testControl.value, parentTopicTitle: 'something' })]));
@@ -44,9 +44,9 @@ describe('QuestionTitleValidator', () => {
       next: (result) => expect(result.titleAlreadyExists.errorMessage).toMatch(
         `a question with title "${testControl.value}" already exists`),
     });
-  });
+  }));
 
-  it('should return an object with a titleAlreadyExists property if the query via QuestionService fails', () => {
+  it('should return an object with a titleAlreadyExists property if the query via QuestionService fails', async(() => {
     const testControl = new FormControl('an-existing-title');
     questionServiceStub.searchForQuestionBy.callsFake(() => throwError(new QuestionServiceError('some error')));
 
@@ -56,9 +56,9 @@ describe('QuestionTitleValidator', () => {
         `the question title "${testControl.value}" could not be verified at this time, please try again later`),
       error: (error => fail(`the error, :${error.message} was unexpected`))
     });
-  });
+  }));
 
-  it('test validator handles more than one search result in array', () => {
+  it('test validator handles more than one search result in array', async(() => {
     const testControl = new FormControl('an-existing-title');
     questionServiceStub.searchForQuestionBy.returns(
       of([
@@ -71,7 +71,7 @@ describe('QuestionTitleValidator', () => {
       next: (result) => expect(result.titleAlreadyExists.errorMessage).toMatch(
         `a question with title "${testControl.value}" already exists`),
     });
-  });
+  }));
 
   afterEach(() => {
     TestBed.resetTestingModule();

--- a/src/app/services/question.service.spec.ts
+++ b/src/app/services/question.service.spec.ts
@@ -165,7 +165,7 @@ describe('QuestionService', () => {
     it('should return an array of matching question dtos if one with a matching title can be found', async(() => {
       // Given
       const questionNameToSearchFor = 'test-question';
-      const expectedSearchResults = {questions: [new QuestionDto({ title: questionNameToSearchFor, parentTopicTitle: 'nonsense' })]};
+      const expectedSearchResults = [new QuestionDto({ title: questionNameToSearchFor, parentTopicTitle: 'nonsense' })];
 
       // When
       const questionSearchObservable = questionService.searchForQuestionBy({title: questionNameToSearchFor});

--- a/src/app/services/question.service.spec.ts
+++ b/src/app/services/question.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { async, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { QuestionService } from './question.service';
@@ -30,7 +30,7 @@ describe('QuestionService', () => {
 
   describe('.getQuestionWithTitle()', () => {
 
-    it('should return a question dto if one with a matching title can be found', () => {
+    it('should return a question dto if one with a matching title can be found', async(() => {
       // Given
       const questionNameToSearchFor = 'test-question';
       const expectedQuestionDto = new QuestionDto({ title: questionNameToSearchFor, parentTopicTitle: 'nonsense' });
@@ -49,9 +49,9 @@ describe('QuestionService', () => {
         }`);
       expect(req.request.method).toEqual('GET');
       req.flush(expectedQuestionDto);
-    });
+    }));
 
-    it('should return null if question could not be found, i.e. error was 404 ', () => {
+    it('should return null if question could not be found, i.e. error was 404 ', async(() => {
       // Given
       const questionNameToSearchFor = 'test-question';
       const expectedQuestionDto = new QuestionDto({ title: questionNameToSearchFor, parentTopicTitle: 'nonsense' });
@@ -73,9 +73,9 @@ describe('QuestionService', () => {
         status: 404,
         statusText: 'not found'
       });
-    });
+    }));
 
-    it('should throw a QuestionServiceError if the service returns codes between 400 and 503, excluding 404', () => {
+    it('should throw a QuestionServiceError if the service returns codes between 400 and 503, excluding 404', async(() => {
       // Given
       const questionNameToSearchFor = 'test-question';
       const expectedQuestionDto = new QuestionDto({ title: questionNameToSearchFor, parentTopicTitle: 'nonsense' });
@@ -100,12 +100,12 @@ describe('QuestionService', () => {
         status: statusCode,
         statusText: errorStatusText
       });
-    });
+    }));
   });
 
   describe('.postQuestionToQuarantine()', () => {
 
-    it('should return an observable of null if the question is submitted successfully', () => {
+    it('should return an observable of null if the question is submitted successfully', async(() => {
       // Given
       const questionToSubmit = new QuestionDto({ title: 'some-title', parentTopicTitle: 'nonsense' });
       const expectedResponseText = 'Successful submission';
@@ -129,9 +129,9 @@ describe('QuestionService', () => {
         status: 201,
         statusText: 'Success'
       });
-    });
+    }));
 
-    it('should throw a QuestionServiceError if the question is not submitted', () => {
+    it('should throw a QuestionServiceError if the question is not submitted', async(() => {
       // Given
       const questionToSubmit = new QuestionDto({ title: 'some-title', parentTopicTitle: 'nonsense' });
       const errorStatusText = 'some generic error message';
@@ -157,12 +157,12 @@ describe('QuestionService', () => {
         status: statusCode,
         statusText: errorStatusText
       });
-    });
+    }));
   });
 
   describe('.searchForQuestionBy()', () => {
 
-    it('should return an array of matching question dtos if one with a matching title can be found', () => {
+    it('should return an array of matching question dtos if one with a matching title can be found', async(() => {
       // Given
       const questionNameToSearchFor = 'test-question';
       const expectedSearchResults = {questions: [new QuestionDto({ title: questionNameToSearchFor, parentTopicTitle: 'nonsense' })]};
@@ -183,9 +183,9 @@ describe('QuestionService', () => {
       ), 'query parameters containing \'title\' and url to /question');
       expect(req.request.method).toEqual('GET');
       req.flush(expectedSearchResults);
-    });
+    }));
 
-    it('should return an empty array if one with a matching title cannot be found', () => {
+    it('should return an empty array if one with a matching title cannot be found', async(() => {
       // Given
       const questionNameToSearchFor = 'test-question';
       const expectedSearchResults = [];
@@ -206,9 +206,9 @@ describe('QuestionService', () => {
       ), 'query parameters containing \'title\' and url to /question');
       expect(req.request.method).toEqual('GET');
       req.flush(expectedSearchResults);
-    });
+    }));
 
-    it('should throw a QuestionServiceError if the service returns codes between 400 and 503', () => {
+    it('should throw a QuestionServiceError if the service returns codes between 400 and 503', async(() => {
       // Given
       const questionNameToSearchFor = 'test-question';
       const errorStatusText = 'some error message';
@@ -234,7 +234,7 @@ describe('QuestionService', () => {
         status: statusCode,
         statusText: errorStatusText
       });
-    });
+    }));
   });
   afterEach(() => {
     httpTestingController.verify();


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

- Fixes the intermittent pass/failure of some unit tests within the application

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

- Test the code
<!-- Add steps to run the tests suite and/or manually test -->

```
npm test
```

## What to Check

Verify that the following are valid

```
Chrome Headless 85.0.4183.121 (Linux x86_64): Executed 64 of 68 (skipped 4) SUCCESS (1.957 secs / 1.714 secs)
TOTAL: 64 SUCCESS
TOTAL: 64 SUCCESS
```

## Other Information

<!-- Add any other helpful information that may be needed here. -->
Not all tests had the Angular `async` helper added for this PR. This was only added to tests that didn't utilise callbacks or promises to ensure jasmine waited for the asynchronous behaviour to complete before reporting the status of their unit test.